### PR TITLE
Fix realm bug in PruneUsersJob

### DIFF
--- a/app/Repositories/Proxmox/Node/ProxmoxAccessRepository.php
+++ b/app/Repositories/Proxmox/Node/ProxmoxAccessRepository.php
@@ -21,7 +21,16 @@ class ProxmoxAccessRepository extends ProxmoxRepository
             ->get('/api2/json/access/users')
             ->json();
 
-        $users = array_map(fn ($user) => UserData::fromRaw($user), $this->getData($response));
+        $users = array_filter($this->getData($response), function ($user) {
+            try {
+                RealmType::from($user['realm-type']);
+                return true;
+            } catch (\ValueError $e) {
+                return false;
+            }
+        });
+
+        $users = array_map(fn ($user) => UserData::fromRaw($user), $users);
 
         return UserData::collection($users);
     }


### PR DESCRIPTION


Filter users by realm type before converting them into UserData in the `getUsers` method in `app/Repositories/Proxmox/Node/ProxmoxAccessRepository.php`.

* Add a check to see if the realm type can be casted to the `RealmType` enum before creating a `UserData` object.
* Ignore users with realm types different than those in the enum.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ConvoyPanel/panel/issues/126?shareId=XXXX-XXXX-XXXX-XXXX).